### PR TITLE
Translucent menu dropdown fix

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -9,6 +9,10 @@ body {
     font-family: var(--font-family);
 }
 
+.my-dropdown .p-menuitem-link {
+  background-color: whitesmoke;
+  opacity: 1;
+}
 
 ui-dropdown-panel .ui-dropdown-items-wrapper {
   overflow: auto;


### PR DESCRIPTION
Change css to opaque and whitesmoke in color.  Issue: #3 