### PR TITLE
implement a shared custom dropdown for Positions

### DIFF
--- a/src/Copilot/SportsPositionSuggestion.md
+++ b/src/Copilot/SportsPositionSuggestion.md
@@ -1,0 +1,61 @@
+Here is the documentation for the StaticDataService class and its GetPositionCodes method:
+
+StaticDataService Documentation
+Overview
+The StaticDataService class provides methods to fetch static data from the API. It is designed to be used as an injectable service in Angular applications.
+
+Dependencies
+HttpClient from @angular/common/http
+Injectable from @angular/core
+Observable from rxjs
+environment from src/environments/environment
+PositionCodesDTO from ./positioncodes
+Service Definition
+    import { HttpClient } from '@angular/common/http';
+    import { Injectable } from '@angular/core';
+    import { Observable } from 'rxjs';
+    import { environment } from 'src/environments/environment';
+    import { PositionCodesDTO } from './positioncodes';
+
+    @Injectable({
+    providedIn: 'root'
+    })
+    export class StaticDataService {
+    baseURL = environment.apiUrl;
+
+    constructor(
+        private http: HttpClient
+    ) { }
+
+    GetPositionCodes(sport: string): Observable<PositionCodesDTO[]> {
+        return this.http.get<PositionCodesDTO[]>(this.baseURL + 'staticdata/positions?sport=' + sport);
+    }
+    }
+
+Properties
+baseURL
+Type: string
+Description: The base URL for the API, retrieved from the environment configuration.
+Constructor
+constructor(http: HttpClient)
+Parameters:
+http: An instance of HttpClient used to make HTTP requests.
+Methods
+GetPositionCodes
+Signature: GetPositionCodes(sport: string): Observable<PositionCodesDTO[]>
+Parameters:
+sport: A string representing the sport for which to fetch position codes.
+Returns: An Observable of an array of PositionCodesDTO.
+Description: This method fetches position codes for a given sport from the API.
+Usage Example
+To use the StaticDataService in a component, follow these steps:
+
+Inject the StaticDataService into your component.
+Call the GetPositionCodes method with the appropriate sport parameter.
+Subscribe to the Observable returned by GetPositionCodes to get the position codes.
+Example Component
+Example Template
+Module Declaration
+Make sure to declare the component in your module:
+
+This documentation provides an overview of the StaticDataService class, its dependencies, properties, methods, and an example of how to use it in an Angular component.

--- a/src/app/common/validators/not-empty.ts
+++ b/src/app/common/validators/not-empty.ts
@@ -1,0 +1,8 @@
+import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+
+export function nonEmptyStringValidator(): ValidatorFn {
+  return (control: AbstractControl): ValidationErrors | null => {
+    const value = control.value;
+    return value && value.trim() !== '' ? null : { nonEmptyString: true };
+  };
+}

--- a/src/app/nhl/components/roster/roster.component.html
+++ b/src/app/nhl/components/roster/roster.component.html
@@ -64,8 +64,12 @@
         </div>
         <div class="detailField">
           <label for="position">Position</label>
-          <input id="position" pInputText formControlName="position" />
-        </div>
+          <app-position-dropdown id="position" [sport]="'nhl'" formControlName="position" />
+          <div *ngIf="nhlForm.get('position')?.invalid && (nhlForm.get('position')?.touched || isSubmitted)">
+            <div class="field-error" *ngIf="nhlForm.get('position')?.errors?.['required']">Position is required.</div>
+            <div class="field-error" *ngIf="nhlForm.get('position')?.errors?.['nonEmptyString']">Position cannot be empty.</div>
+          </div>
+        </div>        
         <div class="detailField">
           <label for="number">Number</label>
           <input id="number" pInputText formControlName="number" />

--- a/src/app/nhl/components/roster/roster.component.ts
+++ b/src/app/nhl/components/roster/roster.component.ts
@@ -1,9 +1,10 @@
 import { Component, OnInit } from '@angular/core';
-import { FormGroup, FormControl, Validators } from '@angular/forms';
-import { NhlService } from '../../services/nhl.service';
-import { NHLRosterDto } from '../../services/nhl';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { switchMap, timer } from 'rxjs';
+import { nonEmptyStringValidator } from 'src/app/common/validators/not-empty';
 import { yearRangeValidator } from 'src/app/common/validators/year-range';
-import { delay, switchMap, timer } from 'rxjs';
+import { NHLRosterDto } from '../../services/nhl';
+import { NhlService } from '../../services/nhl.service';
 
 @Component({
   selector: 'sports-roster',
@@ -35,7 +36,7 @@ export class RosterComponent implements OnInit {
     this.nhlForm = new FormGroup({
       team: new FormControl(''),
       name: new FormControl(''),
-      position: new FormControl(''),
+      position: new FormControl('', [Validators.required, nonEmptyStringValidator()]),
       number: new FormControl(''),
       handed: new FormControl(null, [Validators.required]),
       drafted: new FormControl(null,

--- a/src/app/nhl/nhl.module.ts
+++ b/src/app/nhl/nhl.module.ts
@@ -1,15 +1,13 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { TableModule } from 'primeng/table';
+import { NgModule } from '@angular/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms'; // Import FormsModule
 import { DialogModule } from 'primeng/dialog';
-import { FormsModule } from '@angular/forms'; // Import FormsModule
-import { ReactiveFormsModule } from '@angular/forms'; // Import ReactiveFormsModule
+import { TableModule } from 'primeng/table';
 
-
+import { StaticData } from '../staticdata/staticdata.module';
+import { RosterComponent } from './components/roster/roster.component';
 import { NhlRoutingModule } from './nhl-routing.module';
 import { NhlComponent } from './nhl.component';
-import { RosterComponent } from './components/roster/roster.component';
-
 
 @NgModule({
   declarations: [
@@ -22,6 +20,7 @@ import { RosterComponent } from './components/roster/roster.component';
     DialogModule,
     FormsModule,
     ReactiveFormsModule,
+    StaticData,
     NhlRoutingModule
   ]
 })

--- a/src/app/staticdata/PositionCodesCopilot.md
+++ b/src/app/staticdata/PositionCodesCopilot.md
@@ -1,0 +1,83 @@
+# Copilot Prompt for architecture guidance for the new dropdown
+# ==> @workspace how do I use the service endpoint GetPositionCodes to populate an NHL dropdown for Position from the api call
+
+# During integration this suggestion was heavily refactored, with lots of reprompting
+
+To populate an NHL dropdown for Position using the `GetPositionCodes` method from the `StaticDataService`, follow these steps:
+
+1. **Inject the `StaticDataService` into your component.**
+2. **Call the `GetPositionCodes` method with the 'nhl' parameter.**
+3. **Subscribe to the Observable returned by `GetPositionCodes` to get the position codes.**
+4. **Bind the position codes to the dropdown in your component's template.**
+
+Here is an example implementation:
+
+### Step 1: Inject `StaticDataService` into your component
+
+```typescript
+import { Component, OnInit } from '@angular/core';
+import { StaticDataService } from '../staticdata/services/staticdata.service';
+import { PositionCodesDTO } from '../staticdata/services/positioncodes';
+
+@Component({
+  selector: 'app-nhl-position-dropdown',
+  templateUrl: './nhl-position-dropdown.component.html',
+  styleUrls: ['./nhl-position-dropdown.component.css']
+})
+export class NhlPositionDropdownComponent implements OnInit {
+  positionCodes: PositionCodesDTO[] = [];
+
+  constructor(private staticDataService: StaticDataService) {}
+
+  ngOnInit(): void {
+    this.loadPositionCodes();
+  }
+
+  loadPositionCodes(): void {
+    this.staticDataService.GetPositionCodes('nhl').subscribe(
+      (data: PositionCodesDTO[]) => {
+        this.positionCodes = data;
+      },
+      (error) => {
+        console.error('Error fetching position codes', error);
+      }
+    );
+  }
+}
+
+Step 2: Create the template for the dropdown
+
+<!-- nhl-position-dropdown.component.html -->
+<select>
+  <option *ngFor="let position of positionCodes" [value]="position.code">
+    {{ position.description }}
+  </option>
+</select>
+
+Step 3: Add the component to your module
+
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { AppComponent } from './app.component';
+import { NhlPositionDropdownComponent } from './nhl-position-dropdown/nhl-position-dropdown.component';
+import { HttpClientModule } from '@angular/common/http';
+
+@NgModule({
+  declarations: [
+    AppComponent,
+    NhlPositionDropdownComponent
+  ],
+  imports: [
+    BrowserModule,
+    HttpClientModule
+  ],
+  providers: [],
+  bootstrap: [AppComponent]
+})
+export class AppModule { }
+
+# Working through integration issues #1
+The error NG01203: No value accessor for form control name: 'position' occurs because Angular forms require a value accessor to bridge the form control and the native DOM element or custom component. In your case, the custom component <app-nhl-position-dropdown> needs to implement the ControlValueAccessor interface to work with Angular forms.
+
+Here's how you can implement ControlValueAccessor in your NhlPositionDropdownComponent:
+See PR for surprisingly massive changes

--- a/src/app/staticdata/components/position-dropdown.component.html
+++ b/src/app/staticdata/components/position-dropdown.component.html
@@ -1,0 +1,6 @@
+<!-- Common position-dropdown.component.html -->
+<select [value]="value" id="position-dropdown" (change)="onSelectChange($event)">
+  <option *ngFor="let p of positionCodes" [value]="p.positionCode">
+    {{ p.positionDesc }}
+  </option>
+</select>

--- a/src/app/staticdata/components/position-dropdown.component.ts
+++ b/src/app/staticdata/components/position-dropdown.component.ts
@@ -1,0 +1,88 @@
+// Reusable component for a dropdown list of position codes for a given sport.  Supply the sport parameter to filter the PositionCodes table.
+// Sample usage <app-position-dropdown id="position" [sport]="'nhl'" formControlName="position" />
+
+import { Component, forwardRef, Input, OnInit } from '@angular/core';
+import { AbstractControl, ControlValueAccessor, NG_VALIDATORS, NG_VALUE_ACCESSOR, ValidationErrors } from '@angular/forms';
+import { PositionCodesDTO } from '../services/positioncodes';
+import { StaticDataService } from '../services/staticdata.service';
+
+@Component({
+  selector: 'app-position-dropdown',
+  templateUrl: './position-dropdown.component.html',
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => PositionDropdownComponent),
+      multi: true
+    },
+    {
+      provide: NG_VALIDATORS,
+      useExisting: forwardRef(() => PositionDropdownComponent),
+      multi: true
+    }
+  ]
+})
+export class PositionDropdownComponent implements OnInit, ControlValueAccessor {
+  @Input() sport: string = 'missing';
+  positionCodes: PositionCodesDTO[] = [];
+  value: string = '';
+  errorMessage: string = '';
+
+  constructor(private staticDataService: StaticDataService) { }
+
+  ngOnInit(): void {
+    this.loadPositionCodes();
+  }
+
+  loadPositionCodes(): void {
+    this.staticDataService.GetPositionCodes(this.sport).subscribe(
+      (data: PositionCodesDTO[]) => {
+
+        if (data.length === 0) {
+          this.errorMessage = 'No position codes found for ' + this.sport;
+          throw new Error(this.errorMessage);
+        }
+
+        this.positionCodes = data;
+      },
+      (error) => {
+        console.error('Error fetching position codes for ' + this.sport + ": ", error);
+      }
+    );
+  }
+
+  // Implement ControlValueAccessor
+  onChange: any = () => { };
+  onTouched: any = () => { };
+
+  writeValue(value: any): void {
+    this.value = value;
+  }
+
+  registerOnChange(fn: any): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: any): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState?(isDisabled: boolean): void {
+    // Handle the disabled state if needed
+  }
+
+  onSelectChange(event: any): void {
+    this.value = event.target.value;
+    this.onChange(this.value);
+    this.onTouched();
+  }
+  
+  // Implement Validator
+  validate(control: AbstractControl): ValidationErrors | null {
+    if (this.errorMessage) {
+      return { positionError: this.errorMessage };
+    }
+    return null;
+  }
+
+}

--- a/src/app/staticdata/services/positioncodes.ts
+++ b/src/app/staticdata/services/positioncodes.ts
@@ -1,0 +1,8 @@
+export interface IStaticData {
+}
+
+export interface PositionCodesDTO {
+    sport: string;
+    positionCode: string;
+    positionDesc: string;
+}

--- a/src/app/staticdata/services/staticdata.service.ts
+++ b/src/app/staticdata/services/staticdata.service.ts
@@ -1,0 +1,20 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+import { PositionCodesDTO } from './positioncodes';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class StaticDataService {
+  baseURL = environment.apiUrl;
+
+  constructor(
+    private http: HttpClient
+  ) { }
+
+  GetPositionCodes(sport: string): Observable<PositionCodesDTO[]> {
+    return this.http.get<PositionCodesDTO[]>(this.baseURL + 'staticdata/positions?sport=' + sport);
+  }
+}

--- a/src/app/staticdata/staticdata.module.ts
+++ b/src/app/staticdata/staticdata.module.ts
@@ -1,0 +1,22 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { PositionDropdownComponent } from '../staticdata/components/position-dropdown.component';
+
+@NgModule({
+  declarations: [
+    PositionDropdownComponent
+  ],
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule
+  ],
+  exports: [
+    PositionDropdownComponent,
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule
+  ]
+})
+export class StaticData { }


### PR DESCRIPTION
Implement a reusable component for a dropdown list of position codes for a given sport.  
Supply a sport parameter to filter the PositionCodes table.

Sample usage <app-position-dropdown id="position" [sport]="'nhl'" formControlName="position" />

For GitHub issue #37 
Copilot architecture suggestion is in src/app/staticdata/PositionCodesCopilot.md
