### PR TITLE
Cache the Position codes by Sport

### DIFF
--- a/src/app/staticdata/services/staticdata.service.ts
+++ b/src/app/staticdata/services/staticdata.service.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
+import { tap } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 import { PositionCodesDTO } from './positioncodes';
 
@@ -8,13 +9,24 @@ import { PositionCodesDTO } from './positioncodes';
   providedIn: 'root'
 })
 export class StaticDataService {
-  baseURL = environment.apiUrl;
+  private baseURL = environment.apiUrl;
 
-  constructor(
-    private http: HttpClient
-  ) { }
+  // In-memory cache: key is sport code, value is the positions array
+  private positionCache = new Map<string, PositionCodesDTO[]>();
+
+  constructor(private http: HttpClient) {}
 
   GetPositionCodes(sport: string): Observable<PositionCodesDTO[]> {
-    return this.http.get<PositionCodesDTO[]>(this.baseURL + 'staticdata/positions?sport=' + sport);
+    const cached = this.positionCache.get(sport);
+    if (cached) {
+      // Return cached value as observable, rather than calling the API again
+      return of(cached);
+    }
+
+    // Fetch from API and "tap" into the observable chain to cache the result for this sport
+    return this.http.get<PositionCodesDTO[]>(`${this.baseURL}staticdata/positions?sport=${sport}`)
+      .pipe(
+        tap(data => this.positionCache.set(sport, data))
+      );
   }
 }


### PR DESCRIPTION
<!-- filepath: .github/PULL_REQUEST_TEMPLATE.md -->

## Description

Cache the player Position dropdown, by sport, for better performance.
Retain the cache for the duration of a web session.
This static data does not change often.

## Dependencies
- N/A

Fixes or Implements # (issue) :
Cache the Position dropdown entries [#87](https://github.com/smagara/AgilitySports_web/issues/87)

## Type of change: Performance improvement

Please check relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Test all Add/Edit popup screens for all Sports, ensure the appropriate Positions are populating and functioning
- [ ] Trace the SQL calls and/or observe the logfile to ensure no repeated fetching of Positions for a sport on return to the roster page

## Checklist:

- [x] My code follows the style guidelines of this project, formatting and lint-ing
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules