### PR TITLE
Xssfix - Handle NBA Roster delete error

### DIFF
--- a/src/app/nba/components/roster-list/roster-list.component.html
+++ b/src/app/nba/components/roster-list/roster-list.component.html
@@ -1,4 +1,4 @@
-<h2 class="NBA">National Basketbal Association - Team Rosters</h2>
+<h2 class="NBA">National Basketball Association - Team Rosters</h2>
 
 <div *ngIf="isLoading">Loading...</div>
 <div *ngIf="!isLoading && !roster.length">
@@ -33,7 +33,7 @@
         <td class="actions">
           <button title="Edit" pButton type="button" icon="pi pi-pencil" (click)="editRow.emit(roster)">Edit</button>
           &nbsp;
-          <button title="Delete" pButton type="button" icon="pi pi-delete" (click)="deleteRow.emit(roster)">Delete</button>
+          <button title="Delete" pButton type="button" icon="pi pi-delete" (click)="deleteRow.emit(roster.playerID)">Delete</button>
         </td>
         <td>{{ roster.team }}</td>
         <td>{{ roster.firstName }}</td>

--- a/src/app/nba/components/roster/roster.component.html
+++ b/src/app/nba/components/roster/roster.component.html
@@ -1,5 +1,4 @@
-<div *ngIf="!isLoading && roster.length">
-  <sports-roster-list [roster]="roster"
+<sports-roster-list [roster]="roster"
   [isLoading]="isLoading"
   (addRow)="addRow()"
   (editRow)="editRow($event)"

--- a/src/app/nba/components/roster/roster.component.ts
+++ b/src/app/nba/components/roster/roster.component.ts
@@ -87,10 +87,10 @@ export class RosterComponent implements OnInit {
     this.display = true;
   }
 
-  deleteRow(row: any) {
+  deleteRow(playerID: string) {
     this.resetAction();
     this.display = false;
-    this.delete(row.playerID);
+    this.delete(playerID);
   }
 
   save() {


### PR DESCRIPTION
<!-- filepath: .github/PULL_REQUEST_TEMPLATE.md -->

## Description

On the NBA Roster screen, the Delete button causes an error.  This is a preexisting issue discovered during regression testing and will be fixed in this release.  Fix is to emit the PlayerID rather than NBA roster object in the deleterow event.  Similar code to other sports on the site (NBA, NFL, etc)

## Dependencies
- Piggyback the cross-site scripting (XSS) release

Fixes or Implements # (issue) #95 

## Type of change: Bugfix

Please check relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Unit test locally
- [ ] Integration validation post-deployment

## Checklist:

- [x] My code follows the style guidelines of this project, formatting and lint-ing
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules