### PR TITLE
Disallow interior spaces in Height

### DIFF
--- a/src/app/nba/components/roster/roster.component.ts
+++ b/src/app/nba/components/roster/roster.component.ts
@@ -36,7 +36,7 @@ export class RosterComponent implements OnInit {
       number: new FormControl('', [Validators.required,
         Validators.pattern('^[0-9]+$')]), // numbers only
       height: new FormControl(null, [Validators.required,
-        Validators.pattern('^[0-9]+\' [0-9]{1,2}"$')]), // feet and inches (e.g. 6'9")
+        Validators.pattern('^[0-9]+\'[0-9]{1,2}"$')]), // feet and inches (e.g. 6'9")
       weight: new FormControl(null, [Validators.required,
         Validators.min(98),
         Validators.max(500),

--- a/src/app/nfl/components/roster/roster.component.ts
+++ b/src/app/nfl/components/roster/roster.component.ts
@@ -31,7 +31,7 @@ export class RosterComponent implements OnInit {
       lastName: new FormControl('', [Validators.required, noXssValidator(), nonEmptyStringValidator()]),
       position: new FormControl('', [Validators.required, nonEmptyStringValidator()]),
       number: new FormControl('', [Validators.required, Validators.pattern('^[0-9]+$')]), // numbers only
-      height: new FormControl(null, [Validators.required, Validators.pattern('^[0-9]+\' ?[0-9]{1,2}"$')]), // feet and inches (e.g. 6'9")
+      height: new FormControl(null, [Validators.required, Validators.pattern('^[0-9]+\'?[0-9]{1,2}"$')]), // feet and inches (e.g. 6'9")
       weight: new FormControl(null, [Validators.required, Validators.min(98), Validators.max(500), Validators.pattern('^[0-9]+$')]),
       college: new FormControl('', [noXssValidator()]),
       age: new FormControl('', [Validators.required, Validators.pattern('^[0-9]+$')]), // numbers only


### PR DESCRIPTION
<!-- filepath: .github/PULL_REQUEST_TEMPLATE.md -->

## Description

Standardize Height fields across sports.  Disallow internal spaces between feet and inches, ie 5'11 not 5'&nbsp;11"

## Dependencies
- Database SQL update of existing Height fields # [Issue 22](https://github.com/smagara/AgilitySports_data/issues/22)

Fixes or Implements # (issue)  [Issue 22](https://github.com/smagara/AgilitySports_data/issues/22)

## Type of change
Consistency of data input

Please check relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Local machine Angular Website testing
- [ ] Validation online in Azure

## Checklist:

- [x] My code follows the style guidelines of this project, formatting and lint-ing
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules