### PR TITLE
disable cacheing for the angular deployments to Azure

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -31,7 +31,7 @@ ui-dropdown-panel .ui-dropdown-items-wrapper {
 }
 
 .NFL {
-  background-color: #526914;
+  background-color: #004C54;
   color: #ffffff;
   padding: .5em;
 }

--- a/src/web.config
+++ b/src/web.config
@@ -16,12 +16,9 @@
               <profiles>
                   <!-- Disable caching for HTML files -->
                   <add extension=".html" policy="DisableCache" kernelCachePolicy="DisableCache" />
-                  <!-- Disable caching for JS and CSS files without hashes -->
+                  <!-- Disable caching for JS and CSS files -->
                   <add extension=".js" policy="DisableCache" kernelCachePolicy="DisableCache" />
                   <add extension=".css" policy="DisableCache" kernelCachePolicy="DisableCache" />
-                  <!-- Allow caching for hashed files (they have unique names) -->
-                  <add extension=".js" policy="CacheUntilChange" kernelCachePolicy="CacheUntilChange" />
-                  <add extension=".css" policy="CacheUntilChange" kernelCachePolicy="CacheUntilChange" />
               </profiles>
           </caching>
           <staticContent>


### PR DESCRIPTION
<!-- filepath: .github/PULL_REQUEST_TEMPLATE.md -->

## Description

During deployment of the NFL CRUD update to the AgilitySports angular website, it was discovered that the changes were not reflected in the browser unless the user explicitly refreshed the page.  

```
Trying again with a tweak to web.config to disable all caching of js and css, 
even though they are munged with hash file suffixes.
```

The issue had nothing to do with the GitHub Action upload or download daemon versions, as was previously thought.

Ensure future changes are reflected online without explicit refreshing of the web browser.

## Dependencies
- None

Fixes or Implements # (issue) #80 cache busting

## Type of change: bug fix

Please check relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Test after deployment to Azure website.  Fight the Azure caching as much as possible so that users don't need to hit refresh to see website improvements.

- [ ] Validate Azure web url after deployment, no explicit refresh needed

