### PR TITLE
Fix popup button style issues

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -131,6 +131,35 @@ ui-dropdown-panel .ui-dropdown-items-wrapper {
     width: 100%;
     min-width: auto;
     white-space: nowrap; /* Prevent text wrapping on mobile too */
+    /* Ensure proper button styling on mobile */
+    color: #333 !important;
+    background: linear-gradient(to bottom, #f5f5f5 0%, #e8e8e8 100%) !important;
+    border: 2px solid #666 !important;
+    border-radius: 4px;
+    box-shadow: 
+      0 2px 4px rgba(0, 0, 0, 0.2),
+      inset 0 1px 0 rgba(255, 255, 255, 0.8),
+      inset 0 -1px 0 rgba(0, 0, 0, 0.1);
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+  }
+  
+  .detailButton button:hover {
+    background: linear-gradient(to bottom, #e8e8e8 0%, #d8d8d8 100%) !important;
+    box-shadow: 
+      0 3px 6px rgba(0, 0, 0, 0.25),
+      inset 0 1px 0 rgba(255, 255, 255, 0.9),
+      inset 0 -1px 0 rgba(0, 0, 0, 0.15);
+    transform: translateY(-1px);
+  }
+  
+  .detailButton button:active {
+    background: linear-gradient(to bottom, #d8d8d8 0%, #c8c8c8 100%) !important;
+    box-shadow: 
+      0 1px 2px rgba(0, 0, 0, 0.3),
+      inset 0 1px 2px rgba(0, 0, 0, 0.2);
+    transform: translateY(0);
   }
 }
 


### PR DESCRIPTION
<!-- filepath: .github/PULL_REQUEST_TEMPLATE.md -->

## Description

On an IPhone 14 Pro max the "Save" and "Add" buttons have what looks like grey text. Cancel buttons are ok. Also, they are stacked, not side-by-side.

## Dependencies
- None, NFL, NHL, NBA detail popups

Fixes or Implements # (issue) #107 

## Type of change: Bugfix

Please check relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Local testing with DevTools device emulation does not reproduce the problem
- [ ] Testing will be post-deployment on an actual device

## Checklist:

- [x] My code follows the style guidelines of this project, formatting and lint-ing
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation, if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules