### PR TITLE
Handle empty optional field serialization as NULL

### DIFF
--- a/src/app/mlb/components/roster/roster.component.ts
+++ b/src/app/mlb/components/roster/roster.component.ts
@@ -27,6 +27,15 @@ export class RosterComponent implements OnInit {
 
   constructor (private mlbService: MlbService) {}
 
+  private normalizeOptionalNumber(value: any): number | null {
+    if (value === null || value === undefined || String(value).trim() === '') {
+      return null;
+    }
+
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
   ngOnInit(): void {
     this.mlbForm = new FormGroup({
       teamCode: new FormControl('', [Validators.required, noXssValidator(), nonEmptyStringValidator()]),
@@ -212,9 +221,9 @@ export class RosterComponent implements OnInit {
       birthPlace: source.birthPlace || '',
       bats: this.normalizeBatsForPayload(source.bats),
       throws: this.normalizeThrowsForPayload(source.throws),
-      battingAverage: source.battingAverage || '',
-      homeRuns: source.homeRuns || '',
-      era: source.era || ''
+      battingAverage: this.normalizeOptionalNumber(source.battingAverage),
+      homeRuns: this.normalizeOptionalNumber(source.homeRuns),
+      era: this.normalizeOptionalNumber(source.era)
     };
   }
 

--- a/src/app/nfl/components/roster/roster.component.ts
+++ b/src/app/nfl/components/roster/roster.component.ts
@@ -26,6 +26,15 @@ export class RosterComponent implements OnInit {
 
   constructor(private nflService: NflService) { }
 
+  private normalizeOptionalNumber(value: any): number | null {
+    if (value === null || value === undefined || String(value).trim() === '') {
+      return null;
+    }
+
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
   ngOnInit(): void {
     this.nflForm = new FormGroup({
       team: new FormControl('', [Validators.required, noXssValidator(), nonEmptyStringValidator()]),
@@ -105,8 +114,8 @@ export class RosterComponent implements OnInit {
         weight: this.selectedRow.weight || '',
         dateOfBirth: this.selectedRow.dateOfBirth ? new Date(this.selectedRow.dateOfBirth) : null,
         college: this.selectedRow.college || '',
-        sacks: this.selectedRow.sacks || '',
-        touchdowns: this.selectedRow.touchdowns || ''
+        sacks: this.normalizeOptionalNumber(this.selectedRow.sacks),
+        touchdowns: this.normalizeOptionalNumber(this.selectedRow.touchdowns)
       };
 
       this.nflService.SaveRoster(playerToSave).subscribe({
@@ -147,8 +156,8 @@ export class RosterComponent implements OnInit {
         weight: this.nflForm.get('weight')?.value || '',
         dateOfBirth: this.nflForm.get('dateOfBirth')?.value ? new Date(this.nflForm.get('dateOfBirth')?.value) : null,
         college: this.nflForm.get('college')?.value || '',
-        sacks: this.nflForm.get('sacks')?.value || '',
-        touchdowns: this.nflForm.get('touchdowns')?.value || '',
+        sacks: this.normalizeOptionalNumber(this.nflForm.get('sacks')?.value),
+        touchdowns: this.normalizeOptionalNumber(this.nflForm.get('touchdowns')?.value),
       };
 
       this.nflService.AddRoster(playerToAdd).subscribe({

--- a/src/app/nhl/components/roster/roster.component.ts
+++ b/src/app/nhl/components/roster/roster.component.ts
@@ -25,6 +25,15 @@ export class RosterComponent implements OnInit {
   isSubmitted: boolean = false;
   constructor(private nhlService: NhlService) { }
 
+  private normalizeOptionalNumber(value: any): number | undefined {
+    if (value === null || value === undefined || String(value).trim() === '') {
+      return undefined;
+    }
+
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+
   ngOnInit(): void {
     const currentYear = new Date().getFullYear();
     this.nhlForm = new FormGroup({
@@ -150,15 +159,15 @@ export class RosterComponent implements OnInit {
         name: [this.selectedRow.firstName, this.selectedRow.lastName].filter((x: string) => !!x).join(' ').trim(),
         position: this.selectedRow.position,
         number: this.selectedRow.number,
-        draftYear: this.selectedRow.draftYear,
+        draftYear: this.normalizeOptionalNumber(this.selectedRow.draftYear),
         birthCountry: this.selectedRow.birthCountry,
         birthPlace: this.selectedRow.birthPlace,
         dateOfBirth: this.selectedRow.dateOfBirth ? new Date(this.selectedRow.dateOfBirth) : null,
         handed: this.selectedRow.handed,
-        goals: this.selectedRow.goals,
-        penaltyMinutes: this.selectedRow.penaltyMinutes,
-        points: this.selectedRow.points,
-        savePct: this.selectedRow.savePct
+        goals: this.normalizeOptionalNumber(this.selectedRow.goals),
+        penaltyMinutes: this.normalizeOptionalNumber(this.selectedRow.penaltyMinutes),
+        points: this.normalizeOptionalNumber(this.selectedRow.points),
+        savePct: this.normalizeOptionalNumber(this.selectedRow.savePct)
       };
 
       this.nhlService.SaveRoster(playerToSave).subscribe({
@@ -193,15 +202,15 @@ export class RosterComponent implements OnInit {
         name: [this.nhlForm.get('firstName')?.value, this.nhlForm.get('lastName')?.value].filter((x: string) => !!x).join(' ').trim(),
         position: this.nhlForm.get('position')?.value,
         number: this.nhlForm.get('number')?.value,
-        draftYear: this.nhlForm.get('draftYear')?.value,
+        draftYear: this.normalizeOptionalNumber(this.nhlForm.get('draftYear')?.value),
         birthCountry: this.nhlForm.get('birthCountry')?.value,
         birthPlace: this.nhlForm.get('birthPlace')?.value,
         dateOfBirth: this.nhlForm.get('dateOfBirth')?.value ? new Date(this.nhlForm.get('dateOfBirth')?.value) : null,
         handed: this.nhlForm.get('handed')?.value,
-        goals: this.nhlForm.get('goals')?.value,
-        penaltyMinutes: this.nhlForm.get('penaltyMinutes')?.value,
-        points: this.nhlForm.get('points')?.value,
-        savePct: this.nhlForm.get('savePct')?.value
+        goals: this.normalizeOptionalNumber(this.nhlForm.get('goals')?.value),
+        penaltyMinutes: this.normalizeOptionalNumber(this.nhlForm.get('penaltyMinutes')?.value),
+        points: this.normalizeOptionalNumber(this.nhlForm.get('points')?.value),
+        savePct: this.normalizeOptionalNumber(this.nhlForm.get('savePct')?.value)
       };
 
       this.nhlService.AddRoster(playerToAdd).subscribe({


### PR DESCRIPTION
<!-- filepath: .github/PULL_REQUEST_TEMPLATE.md -->

## Description

Post-deployment bugfix: ensure all optional `stats` fields are properly serialized to NULLs instead of empty strings to address upsert fails on Azure.

## Dependencies
- First dependency
- Second dependency

Fixes or Implements # (issue) #110 

## Type of change:

- [x] Bug fix
- [ ] Enhancement
- [ ] DevOps
- [ ] Other:

Please check relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Local web testing.

## Checklist:

- [x] I have opened my PR against the staging branch, NOT against main
- [x] I have personally reviewed any AI-provided suggestions
- [x] I have requested a Copilot review of this PR
- [ ] My code follows the style guidelines of this project, formatting and lint-ing
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
