### PR TITLE
Handle Copilot PR review feedback

### DIFF
--- a/src/app/mlb/components/roster/roster.component.spec.ts
+++ b/src/app/mlb/components/roster/roster.component.spec.ts
@@ -114,4 +114,37 @@ describe('RosterComponent', () => {
 
     expect(component.roster[0].league).toBe('AB');
   });
+
+  it('should prefer details array over message and fallback in API errors', () => {
+    const error = {
+      error: {
+        details: ['detail one', 'detail two'],
+        message: 'message text'
+      }
+    };
+
+    const result = (component as any).buildApiErrorMessage(error, 'fallback text');
+
+    expect(result).toBe('detail one detail two');
+  });
+
+  it('should use message when details are not present', () => {
+    const error = {
+      error: {
+        message: 'message text'
+      }
+    };
+
+    const result = (component as any).buildApiErrorMessage(error, 'fallback text');
+
+    expect(result).toBe('message text');
+  });
+
+  it('should use fallback when details and message are missing', () => {
+    const error = { error: {} };
+
+    const result = (component as any).buildApiErrorMessage(error, 'fallback text');
+
+    expect(result).toBe('fallback text');
+  });
 });

--- a/src/app/mlb/components/roster/roster.component.ts
+++ b/src/app/mlb/components/roster/roster.component.ts
@@ -57,11 +57,11 @@ export class RosterComponent implements OnInit {
       firstName: new FormControl('', [Validators.required, noXssValidator(), nonEmptyStringValidator()]),
       lastName: new FormControl('', [Validators.required, noXssValidator(), nonEmptyStringValidator()]),
       position: new FormControl('', [Validators.required]),
-      number: new FormControl('', [Validators.required, Validators.pattern('^(?:[0-9]|[1-9][0-9])$')]),
+      number: new FormControl('', [Validators.required, Validators.pattern('^[0-9]{1,3}$')]),
       draftYear: new FormControl('', [yearRangeValidator(1900, new Date().getFullYear()), Validators.pattern('^[0-9]{4}$')]),
       seasonYear: new FormControl(new Date().getFullYear(), [Validators.required, yearRangeValidator(1900, new Date().getFullYear() + 1), Validators.pattern('^[0-9]{4}$')]),
       height: new FormControl('', [Validators.required, Validators.pattern("^[0-9]+'[0-9]{1,2}\"$")]),
-      weight: new FormControl('', [Validators.required, Validators.min(98), Validators.max(400), Validators.pattern('^[0-9]{2,3}$')]),
+      weight: new FormControl('', [Validators.required, Validators.min(98), Validators.max(500), Validators.pattern('^[0-9]{2,3}$')]),
       dateOfBirth: new FormControl('', [Validators.required, yearRangeValidator(1900, new Date().getFullYear()), Validators.pattern('^(0[1-9]|1[0-2])/(0[1-9]|[12][0-9]|3[01])/(19|20)\\d{2}$')]),
       birthCountry: new FormControl('', [noXssValidator()]),
       birthCityState: new FormControl('', [noXssValidator()]),
@@ -227,7 +227,7 @@ export class RosterComponent implements OnInit {
 
   private buildRosterPayload(source: any, playerId: number): MLBRosterDto {
     return {
-      playerId: playerId > 0 ? playerId : 0,
+      playerId: playerId > 0 ? playerId : -1,
       teamCode: String(source.teamCode || '').trim().toUpperCase(),
       teamName: source.teamName || this.lookupTeamShortName(String(source.teamCode || '').trim().toUpperCase()),
       firstName: source.firstName || '',

--- a/src/app/nba/components/roster-detail/roster-detail.component.html
+++ b/src/app/nba/components/roster-detail/roster-detail.component.html
@@ -66,8 +66,8 @@
             between
             1900 - Current Year.</div>
         </div>
-</div>
-        <div class="detailField">
+      </div>
+      <div class="detailField">
           <label for="height">Height</label>
           <input id="height" pInputText formControlName="height" maxlength="10" placeholder="Feet-Inches" appTrim />
           <div *ngIf="nbaForm.get('height')?.invalid && (nbaForm.get('height')?.touched || isSubmitted)">
@@ -102,13 +102,13 @@
         <div class="detailField">
           <label for="birthCountry">Birth Country</label>
           <input id="birthCountry" pInputText formControlName="birthCountry" maxlength="50" appTrim />
-          <div class="field-error" *ngIf="nbaForm.get('birthCountry')?.errors?.['xss']">Input cannot contain &lt; or
+          <div class="field-error" *ngIf="nbaForm.get('birthCountry')?.errors?.['xss'] && (nbaForm.get('birthCountry')?.touched || isSubmitted)">Input cannot contain &lt; or
             &gt; characters.</div>
         </div>
         <div class="detailField">
           <label for="birthCityState">Birth Place</label>
           <input id="birthCityState" pInputText formControlName="birthCityState" maxlength="50" appTrim />
-          <div class="field-error" *ngIf="nbaForm.get('birthCityState')?.errors?.['xss']">Input cannot contain &lt; or
+          <div class="field-error" *ngIf="nbaForm.get('birthCityState')?.errors?.['xss'] && (nbaForm.get('birthCityState')?.touched || isSubmitted)">Input cannot contain &lt; or
             &gt;
             characters.</div>
         </div>

--- a/src/app/nba/components/roster/roster.component.ts
+++ b/src/app/nba/components/roster/roster.component.ts
@@ -220,7 +220,7 @@ export class RosterComponent implements OnInit {
         league: this.nbaForm.get('league')?.value || '',
         position: this.normalizeNbaPositionCode(this.nbaForm.get('position')?.value),
         number: this.nbaForm.get('number')?.value || '',
-        draftYear: this.nbaForm.get('draftYear')?.value || '',
+        draftYear: this.normalizeOptionalNumber(this.nbaForm.get('draftYear')?.value),
         seasonYear: this.normalizeOptionalNumber(this.nbaForm.get('seasonYear')?.value),
         height: feetInchesToInches(this.nbaForm.get('height')?.value || ''),
         weight: this.nbaForm.get('weight')?.value || '',

--- a/src/app/nhl/components/roster/roster.component.ts
+++ b/src/app/nhl/components/roster/roster.component.ts
@@ -74,7 +74,7 @@ export class RosterComponent implements OnInit {
       next: data => {
         this.roster = (data || []).map((item: any) => ({
           ...item,
-          birthCityState: item?.birthCityState ?? item?.birthCityState ?? ''
+          birthCityState: item?.birthCityState ?? item?.BirthCityState ?? ''
         }));
         this.isLoading = false;
       },
@@ -146,7 +146,7 @@ export class RosterComponent implements OnInit {
       weight: row.weight || '',
       dateOfBirth: row.dateOfBirth ? formatDateMMDDYYYY(new Date(row.dateOfBirth)) : '',
       birthCountry: row.birthCountry || '',
-      birthCityState: row.birthCityState || row.birthCityState || '',
+      birthCityState: row.birthCityState || row.BirthCityState || '',
       college: row.college || '',
       playerId: row.playerId || '',
       handed: row.handed || '',


### PR DESCRIPTION
<!-- filepath: .github/PULL_REQUEST_TEMPLATE.md -->

## Description

Handle Copilot PR review comments from the last push, to avoid piling up as technical debt.  Then that's it. I'm not asking for a Copilot review of this review feedback. 

Forward!

<details>
<summary>:file_folder: Copilot PR-review recommendations</summary>

- In [src/app/nhl/components/roster/roster.component.ts]
The roster normalization maps birthCityState to itself twice (a ?? a ?? ''), which is redundant and makes it easy to miss real fallback behavior. This can be simplified to a single nullish-coalescing fallback to keep the mapping clear.
This issue also appears on line 148 of the same file.

-  In [src/app/nba/components/roster/roster.component.ts]
NBARosterDto.draftYear is typed as number | null, but the add payload currently sends a string ('') when empty. This can cause API/model binding issues; normalize it the same way as other numeric optional fields.

-  In [src/app/nba/components/roster-detail/roster-detail.component.html]
The Birth Country XSS error is displayed without the usual "touched || isSubmitted" guard used elsewhere in this dialog. That can surface validation messages before the user interacts with the field (e.g., when values are patched programmatically).

-  In [src/app/nba/components/roster-detail/roster-detail.component.html]Same as Birth Country: the Birth Place XSS error should be gated behind "touched || isSubmitted" for consistency with the rest of the form validation UX.

-  In [src/app/nba/components/roster-detail/roster-detail.component.html]There is a mis-indented closing </div> here that breaks the otherwise consistent structure/indentation of the template, making it harder to visually verify tag nesting (and easier to introduce real mismatched-tag bugs).

-  In [src/app/mlb/components/roster/roster.component.ts]
The MLB player number validator now only allows 1–2 digits, but the UI allows up to 3 digits (maxlength="3") and the error message says only "numeric". This will incorrectly reject valid 3-digit numbers.

-  In [src/app/mlb/components/roster/roster.component.ts]
MLB weight max is set to 400 here, while the other roster forms in this PR (NFL/NHL/NBA) use 500. Given the PR goal of standardizing popup validation, this inconsistency is likely unintended and will reject weights between 401–500.

-  In [src/app/mlb/components/roster/roster.component.ts]buildRosterPayload converts non-positive IDs to 0, but add() passes -1 (and other sports in this repo use -1) to indicate "new". If the API expects the sentinel, this will change behavior for inserts. Preserve the sentinel value instead of coercing to 0.

-  In [src/app/mlb/components/roster/roster.component.ts]New buildApiErrorMessage() logic influences user-visible error handling, but there are no unit tests covering its precedence rules (details[] vs message vs fallback). Adding a small set of tests would help prevent regressions as API error formats evolve.

</details>

## Dependencies
- [x] Successful V2 data model, API, and web deployments

Fixes or Implements # (issue) #110 

## Type of change:

- [x] Bug fix
- [ ] Enhancement
- [ ] DevOps
- [ ] Other:

Please check relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Local web testing
- [x] Karma tests

<details>
<summary>:file_folder:  Karma test result</summary>

<img width="911" height="630" alt="image" src="https://github.com/user-attachments/assets/1b45fc92-3764-443f-a067-751fa2322420" />
</details>

## Checklist:

- [x] I have opened my PR against the staging branch, NOT against main
- [x] I have personally reviewed any AI-provided suggestions
- [ ] I have requested a Copilot review of this PR
- [ ] My code follows the style guidelines of this project, formatting and lint-ing
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
